### PR TITLE
Add support for CH340 on MacOSX

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -28,7 +28,7 @@ namespace Config
     *Org = "Jedi98",
     *App = "Antenna Analyzer",
     *DOM_ENCODING = "UTF-8",
-    *SERIAL_DEV_FILTER = "ttyUSB*;tty.usbserial*;rfcomm*";
+    *SERIAL_DEV_FILTER = "ttyUSB*;tty.usbserial*;rfcomm*;tty.wchusbserial*";
 
   QString dir_data;
   double swr_max, swr_bw_max, Z_Target;


### PR DESCRIPTION
CH340 serial converter is getting more popular in Sark100 clones,
so it should be on a whitelist.